### PR TITLE
Better callback URL

### DIFF
--- a/Controller/Component/ExtAuthComponent.php
+++ b/Controller/Component/ExtAuthComponent.php
@@ -47,7 +47,7 @@ class ExtAuthComponent extends Component {
 		$this->settings = array_merge($this->settings, array(
 
 			// Default Settings
-			'callbackURL'                   => 'http://{SERVER_HOST}/auth_callback/{PROVIDER}',
+			'callbackURL'                   => Router::url('/', true).'/auth_callback/{PROVIDER}',
 			'sessionVariableRequestToken'   => 'request_token',
 			'sessionVariableAccessToken'    => 'access_token',
 


### PR DESCRIPTION
I installed the CakePHP into a subdirectory so the default {SERVER_HOST} solution pointed to a wrong URL.
This workaround was better for us. (Now I can deploy the same code to the production server too, without any changes.)
